### PR TITLE
Add parameterization for signals, in the load test

### DIFF
--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -432,7 +432,8 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
         // if signalToOpRatio is unspecified, take the default value as 0. Else, round it up
         const signalsPerOp: number = (typeof config.testConfig.signalToOpRatio === 'undefined') ? 
                                          0 : Math.ceil(config.testConfig.signalToOpRatio); 
-        const opsGapMs = cycleMs / opsPerCycle;
+        const opsPlusSignalsPerCycle: number = (opsPerCycle + opsPerCycle*signalsPerOp)
+        const opsGapMs = cycleMs / opsPlusSignalsPerCycle;
         try {
             while (dataModel.counter.value < clientSendCount && !this.disposed) {
                 // this enables a quick ramp down. due to restart, some clients can lag

--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -429,6 +429,9 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
 
         const clientSendCount = config.testConfig.totalSendCount / config.testConfig.numClients;
         const opsPerCycle = config.testConfig.opRatePerMin * cycleMs / 60000;
+        // if signalToOpRatio is unspecified, take the default value as 0. Else, round it up
+        const signalsPerOp: number = (typeof config.testConfig.signalToOpRatio === 'undefined') ? 
+                                         0 : Math.ceil(config.testConfig.signalToOpRatio); 
         const opsGapMs = cycleMs / opsPerCycle;
         try {
             while (dataModel.counter.value < clientSendCount && !this.disposed) {
@@ -442,7 +445,10 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
 
                 if (dataModel.haveTaskLock()) {
                     dataModel.counter.increment(1);
-                    this.runtime.submitSignal("test-signal", true)
+                    for (let count = 0; count < signalsPerOp; count++)
+                    {
+                        this.runtime.submitSignal("generic-signal", true)
+                    }
                     if (dataModel.counter.value % opsPerCycle === 0) {
                         await dataModel.blobFinish();
                         dataModel.abandonTask();

--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -31,6 +31,7 @@ export interface IRunConfig {
 export interface ILoadTest {
     run(config: IRunConfig, reset: boolean): Promise<boolean>;
     detached(config: Omit<IRunConfig, "runId">): Promise<LoadTestDataStoreModel>;
+    getRuntime(): Promise<IFluidDataStoreRuntime>;
 }
 
 const taskManagerKey = "taskManager";
@@ -441,6 +442,7 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
 
                 if (dataModel.haveTaskLock()) {
                     dataModel.counter.increment(1);
+                    this.runtime.submitSignal("test-signal", true)
                     if (dataModel.counter.value % opsPerCycle === 0) {
                         await dataModel.blobFinish();
                         dataModel.abandonTask();
@@ -461,6 +463,9 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
             }
             dataModel.printStatus();
         }
+    }
+    public async getRuntime(){
+        return this.runtime;
     }
 }
 

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -382,8 +382,15 @@ async function setupOpsMetrics(container: IContainer, logger: ITelemetryLogger, 
 
     let submittedSignals = 0;
     testRuntime.on("signal", (message: IInboundSignalMessage, local: boolean) => {
-        if (message.type === "test-signal" && local === true) {
+        if (message.type === "generic-signal" && local === true) {
             submittedSignals += 1;
+        }
+    });
+
+    let receivedSignals = 0;
+    testRuntime.on("signal", (message: IInboundSignalMessage, local: boolean) => {
+        if (message.type === "generic-signal" && local === false) {
+            receivedSignals += 1;
         }
     });
 
@@ -419,10 +426,22 @@ async function setupOpsMetrics(container: IContainer, logger: ITelemetryLogger, 
                 userName: getUserName(container),
             });
         }
+        if (receivedSignals > 0) {
+            logger.send({
+                category: "metric",
+                eventName: "Fluid Signals Received",
+                testHarnessEvent: true,
+                value: receivedSignals,
+                clientId: container.clientId,
+                userName: getUserName(container),
+            });
+        }
+
 
         submitedOps = 0;
         receivedOps = 0;
         submittedSignals = 0;
+        receivedSignals = 0;
 
         t = setTimeout(sendMetrics, progressIntervalMs);
     };

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -414,7 +414,7 @@ async function setupOpsMetrics(container: IContainer, logger: ITelemetryLogger, 
                 category: "metric",
                 eventName: "Fluid Signals Submitted",
                 testHarnessEvent: true,
-                value: receivedOps,
+                value: submittedSignals,
                 clientId: container.clientId,
                 userName: getUserName(container),
             });

--- a/packages/test/test-service-load/src/testConfigFile.ts
+++ b/packages/test/test-service-load/src/testConfigFile.ts
@@ -20,6 +20,7 @@ export interface ILoadTestConfig {
     numClients: number,
     totalSendCount: number,
     readWriteCycleMs: number,
+    signalToOpRatio?: number,
     faultInjectionMaxMs?: number,
     faultInjectionMinMs?: number,
     /**

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -61,6 +61,7 @@
         },
         "scale": {
             "opRatePerMin": 60,
+            "signalToOpRatio": 25, 
             "progressIntervalMs": 20000,
             "numClients": 10,
             "totalSendCount": 70000,


### PR DESCRIPTION
- Add parameter `signalToOpRatio`, to specify the configuration for signals
- Log and enable Submitted and Received Signals metrics
- Add `signalToOpRatio` parameter to the `ILoadTestConfig` interface
- Add and Implement async function `getRuntime()` through the `ILoadTest` interface, which exposes the runtime needed to access signal events
- If undefined, `signalsPerOp` is set to a default value of 0
- Additionally, `opsGapMs` is decreased (i.e., the denominator is increased) to take signals into consideration