### PR TITLE
Decouple signals and ops

### DIFF
--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -417,32 +417,27 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
         // To set that up we start each client in a staggered way, each will independently go thru write
         // and listen cycles
 
-        let t: NodeJS.Timeout | undefined;
+        let timeout: NodeJS.Timeout | undefined;
         if (config.verbose) {
             const printProgress = () => {
                 dataModel.printStatus();
-                t = setTimeout(printProgress, config.testConfig.progressIntervalMs);
+                timeout = setTimeout(printProgress, config.testConfig.progressIntervalMs);
             };
-            t = setTimeout(printProgress, config.testConfig.progressIntervalMs);
+            timeout = setTimeout(printProgress, config.testConfig.progressIntervalMs);
         }
 
-
-        const opsRun = this.sendOps(dataModel, config, t)
-        // const signalsRun = this.sendSignals()
-        // const runResult = await Promise.all([opsRun, signalsRun]);
-        const runResult = await opsRun;
-        return runResult;
+        const opsRun = this.sendOps(dataModel, config, timeout)
+        const signalsRun = this.sendSignals(config, timeout)
+        const runResult = await Promise.all([opsRun, signalsRun]); //runResult if of type [boolean, void] as we return boolean for Ops alone based on runtime.disposed value
+        return runResult[0];
     }
     async getRuntime() {
         return this.runtime;
     }
-    async sendOps(dataModel: LoadTestDataStoreModel, config: IRunConfig, t: NodeJS.Timeout | undefined){
+    async sendOps(dataModel: LoadTestDataStoreModel, config: IRunConfig, timeout: NodeJS.Timeout | undefined){
         const cycleMs = config.testConfig.readWriteCycleMs;
         const clientSendCount = config.testConfig.totalSendCount / config.testConfig.numClients;
         const opsPerCycle = config.testConfig.opRatePerMin * cycleMs / 60000;
-        // if signalToOpRatio is unspecified, take the default value as 0. Else, round it up
-        const signalsPerOp: number = (typeof config.testConfig.signalToOpRatio === 'undefined') ? 
-                                         0 : Math.ceil(config.testConfig.signalToOpRatio); 
         const opsGapMs = cycleMs / opsPerCycle;
         try {
             while (dataModel.counter.value < clientSendCount && !this.disposed) {
@@ -455,9 +450,6 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
                 }
                 if (dataModel.haveTaskLock()) {
                     dataModel.counter.increment(1);
-                    for (let count = 0; count < signalsPerOp; count++) {
-                        this.runtime.submitSignal("generic-signal", true);
-                    }
                     if (dataModel.counter.value % opsPerCycle === 0) {
                         await dataModel.blobFinish();
                         dataModel.abandonTask();
@@ -476,15 +468,35 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
             return !this.runtime.disposed;
         }
         finally {
-            if (t !== undefined) {
-                clearTimeout(t);
+            if (timeout !== undefined) {
+                clearTimeout(timeout);
             }
             dataModel.printStatus();
         }
     }
-    // async sendSignals(){
-
-    // }
+    async sendSignals(config: IRunConfig, timeout: NodeJS.Timeout | undefined){
+        const clientSignalsSendCount = (typeof config.testConfig.totalSignalsSendCount === 'undefined') ? 
+                                        0 : config.testConfig.totalSignalsSendCount / config.testConfig.numClients;
+        const cycleMs = config.testConfig.readWriteCycleMs;
+        const signalsPerCycle = (typeof config.testConfig.signalsPerMin === 'undefined') ? 
+                                 0 : config.testConfig.signalsPerMin * cycleMs / 60000;
+        const signalsGapMs = cycleMs / signalsPerCycle;
+        var submittedSignals = 0;
+        try {
+            while (submittedSignals < clientSignalsSendCount) {
+                // all the clients are sending signals; with signals, there is no particular need to have staggered writers and readers
+                this.runtime.submitSignal("generic-signal", true);
+                submittedSignals++;
+                // Random jitter of +- 50% of signalGapMs
+                await delay(signalsGapMs + signalsGapMs * random.real(0, .5, true)(config.randEng));  
+            }
+        }
+        finally {
+            if (timeout !== undefined) {
+                clearTimeout(timeout);
+            }
+        }
+    }
 }
 
 const LoadTestDataStoreInstantiationFactory = new DataObjectFactory(

--- a/packages/test/test-service-load/src/testConfigFile.ts
+++ b/packages/test/test-service-load/src/testConfigFile.ts
@@ -19,8 +19,9 @@ export interface ILoadTestConfig {
     progressIntervalMs: number,
     numClients: number,
     totalSendCount: number,
+    totalSignalsSendCount?: number,
     readWriteCycleMs: number,
-    signalToOpRatio?: number,
+    signalsPerMin?: number,
     faultInjectionMaxMs?: number,
     faultInjectionMinMs?: number,
     /**

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -54,7 +54,8 @@
         },
         "debug_signals_nofault": {
             "opRatePerMin": 33.6,
-            "signalToOpRatio": 27,
+            "signalsPerMin": 453.6,
+            "totalSignalsSendCount": 81000,
             "progressIntervalMs": 5000,
             "numClients": 2,
             "totalSendCount": 3000,
@@ -78,7 +79,8 @@
         },
         "scale_with_signals": {
             "opRatePerMin": 33.6,
-            "signalsPerMin": 27, 
+            "signalsPerMin": 453.6, 
+            "totalSignalsSendCount": 1890000,
             "progressIntervalMs": 20000,
             "numClients": 10,
             "totalSendCount": 70000,
@@ -88,7 +90,8 @@
         },
         "custom_scale_with_signals_200": {
             "opRatePerMin": 33.6,
-            "signalToOpRatio": 27, 
+            "signalsPerMin": 453.6, 
+            "totalSignalsSendCount": 1890000,
             "progressIntervalMs": 20000,
             "numClients": 200,
             "totalSendCount": 70000,
@@ -98,7 +101,8 @@
         },
         "custom_scale_with_signals_2": {
             "opRatePerMin": 33.6,
-            "signalToOpRatio": 27, 
+            "signalsPerMin": 453.6, 
+            "totalSignalsSendCount": 1890000,
             "progressIntervalMs": 20000,
             "numClients": 2,
             "totalSendCount": 70000,

--- a/packages/test/test-service-load/testConfig.json
+++ b/packages/test/test-service-load/testConfig.json
@@ -53,7 +53,7 @@
             "faultInjectionMaxMs": 50000
         },
         "debug_signals_nofault": {
-            "opRatePerMin": 32.6,
+            "opRatePerMin": 33.6,
             "signalToOpRatio": 27,
             "progressIntervalMs": 5000,
             "numClients": 2,
@@ -77,8 +77,8 @@
             "faultInjectionMaxMs": 1800000
         },
         "scale_with_signals": {
-            "opRatePerMin": 32.6,
-            "signalToOpRatio": 27, 
+            "opRatePerMin": 33.6,
+            "signalsPerMin": 27, 
             "progressIntervalMs": 20000,
             "numClients": 10,
             "totalSendCount": 70000,
@@ -87,7 +87,7 @@
             "faultInjectionMaxMs": 1800000
         },
         "custom_scale_with_signals_200": {
-            "opRatePerMin": 32.6,
+            "opRatePerMin": 33.6,
             "signalToOpRatio": 27, 
             "progressIntervalMs": 20000,
             "numClients": 200,
@@ -97,7 +97,7 @@
             "faultInjectionMaxMs": 1800000
         },
         "custom_scale_with_signals_2": {
-            "opRatePerMin": 32.6,
+            "opRatePerMin": 33.6,
             "signalToOpRatio": 27, 
             "progressIntervalMs": 20000,
             "numClients": 2,


### PR DESCRIPTION
- Add `async sendOps` and `async sendSignals` functions 
- Decouple signals from ops and trigger them independent of each other
- Replace the `signalToOpRatio` parameter with the `signalsPerMin` parameter