### PR TITLE
Add Op size metric

### DIFF
--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -377,10 +377,14 @@ async function setupOpsMetrics(container: IContainer, logger: ITelemetryLogger, 
         }
     };
 
+    let submitedOpsSize = 0;
+    let receivedOpsSize = 0;
     let submitedOps = 0;
     container.deltaManager.on("submitOp", (message) => {
         if (message?.type === "op") {
             submitedOps++;
+            var currOpSize = (JSON.stringify(message)).length;
+            submitedOpsSize += currOpSize;
         }
     });
 
@@ -388,6 +392,8 @@ async function setupOpsMetrics(container: IContainer, logger: ITelemetryLogger, 
     container.deltaManager.on("op", (message) => {
         if (message?.type === "op") {
             receivedOps++;
+            var currOpSize = (JSON.stringify(message)).length;
+            receivedOpsSize += currOpSize;
         }
     });
 
@@ -447,12 +453,35 @@ async function setupOpsMetrics(container: IContainer, logger: ITelemetryLogger, 
                 userName: getUserName(container),
             });
         }
+        if (submitedOps > 0) {
+            logger.send({
+                category: "metric",
+                eventName: "Fluid Operations Size Sent",
+                testHarnessEvent: true,
+                value: submitedOpsSize,
+                clientId: container.clientId,
+                userName: getUserName(container),
+            });
+        }
+        
+        if (receivedOps > 0) {
+            logger.send({
+                category: "metric",
+                eventName: "Fluid Operations Size Received",
+                testHarnessEvent: true,
+                value: receivedOpsSize,
+                clientId: container.clientId,
+                userName: getUserName(container),
+            });
+        }
 
 
         submitedOps = 0;
         receivedOps = 0;
         submittedSignals = 0;
         receivedSignals = 0;
+        submitedOpsSize = 0;
+        receivedOpsSize = 0;
 
         t = setTimeout(sendMetrics, progressIntervalMs);
     };

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -377,14 +377,14 @@ async function setupOpsMetrics(container: IContainer, logger: ITelemetryLogger, 
         }
     };
 
-    let submitedOpsSize = 0;
+    let submittedOpsSize = 0;
     let receivedOpsSize = 0;
-    let submitedOps = 0;
+    let submittedOps = 0;
     container.deltaManager.on("submitOp", (message) => {
         if (message?.type === "op") {
-            submitedOps++;
+            submittedOps++;
             var currOpSize = (JSON.stringify(message)).length;
-            submitedOpsSize += currOpSize;
+            submittedOpsSize += currOpSize;
         }
     });
 
@@ -413,12 +413,12 @@ async function setupOpsMetrics(container: IContainer, logger: ITelemetryLogger, 
 
     let t: NodeJS.Timeout | undefined;
     const sendMetrics = () => {
-        if (submitedOps > 0) {
+        if (submittedOps > 0) {
             logger.send({
                 category: "metric",
                 eventName: "Fluid Operations Sent",
                 testHarnessEvent: true,
-                value: submitedOps,
+                value: submittedOps,
                 clientId: container.clientId,
                 userName: getUserName(container),
             });
@@ -453,12 +453,12 @@ async function setupOpsMetrics(container: IContainer, logger: ITelemetryLogger, 
                 userName: getUserName(container),
             });
         }
-        if (submitedOps > 0) {
+        if (submittedOps > 0) {
             logger.send({
                 category: "metric",
-                eventName: "Fluid Operations Size Sent",
+                eventName: "Size of Fluid Operations Sent",
                 testHarnessEvent: true,
-                value: submitedOpsSize,
+                value: submittedOpsSize,
                 clientId: container.clientId,
                 userName: getUserName(container),
             });
@@ -467,7 +467,7 @@ async function setupOpsMetrics(container: IContainer, logger: ITelemetryLogger, 
         if (receivedOps > 0) {
             logger.send({
                 category: "metric",
-                eventName: "Fluid Operations Size Received",
+                eventName: "Size of Fluid Operations Received",
                 testHarnessEvent: true,
                 value: receivedOpsSize,
                 clientId: container.clientId,
@@ -476,11 +476,11 @@ async function setupOpsMetrics(container: IContainer, logger: ITelemetryLogger, 
         }
 
 
-        submitedOps = 0;
+        submittedOps = 0;
         receivedOps = 0;
         submittedSignals = 0;
         receivedSignals = 0;
-        submitedOpsSize = 0;
+        submittedOpsSize = 0;
         receivedOpsSize = 0;
 
         t = setTimeout(sendMetrics, progressIntervalMs);


### PR DESCRIPTION
For more information about how to contribute to this repo, visit [this page](https://github.com/microsoft/FluidFramework/blob/main/CONTRIBUTING.md).

For specific guidelines for Pull Requests in this repo, visit [this wiki page](https://github.com/microsoft/FluidFramework/wiki/PR-Guidelines#guidelines).

The sections included below are suggestions for what you may want to include.
Feel free to remove or alter parts of this template that do not offer value for your specific change.

## Description

> Added Op size client metrics for submitted ops and received ops to reflect their size. The size shown in the metrics contains additional overhead data along with the true Op value being sent.