### PR TITLE
CLP scenario integration

### DIFF
--- a/packages/test/test-drivers/src/odspTestDriver.ts
+++ b/packages/test/test-drivers/src/odspTestDriver.ts
@@ -394,12 +394,8 @@ export class OdspTestDriver implements ITestDriver {
     }
 
     // Executes the API call to set sensitivity labels on file with provided itemID
-    public static async setSensitivityLabel(siteUrl: string, itemId: string, labelId: string, loginConfig: IOdspTestLoginInfo)    {
-        const tokenConfig: TokenConfig = {
-            ...loginConfig,
-            ...getMicrosoftConfiguration(),
-        };
-        var storageToken = await this.getStorageToken({ siteUrl, refresh: true }, tokenConfig);
+    public async setSensitivityLabel(siteUrl: string, itemId: string, labelId: string)    {
+        var storageToken = await this.getStorageToken({ siteUrl, refresh: true });
         var token = "Bearer " + storageToken;
     
         var raw = JSON.stringify({
@@ -425,16 +421,12 @@ export class OdspTestDriver implements ITestDriver {
     }
 
     // Executes the API call to extract sensitivity labels on file with provided itemID
-    public static async extractSensitivityLabel(siteUrl: string, itemId: string, loginConfig: IOdspTestLoginInfo)
+    public async extractSensitivityLabel(siteUrl: string, itemId: string)
     {
-        const tokenConfig: TokenConfig = {
-            ...loginConfig,
-            ...getMicrosoftConfiguration(),
-        };
-        var storageToken = await this.getStorageToken({ siteUrl, refresh: true }, tokenConfig);
+        var storageToken = await this.getStorageToken({ siteUrl, refresh: true });
         const authRequestInfo = {
             accessToken: storageToken,
-            refreshTokenFn: async () => this.getStorageToken({ siteUrl, refresh: true }, tokenConfig),
+            refreshTokenFn: async () => this.getStorageToken({ siteUrl, refresh: true }),
         };
         var requestOptions = {
         redirect: 'follow'
@@ -447,16 +439,12 @@ export class OdspTestDriver implements ITestDriver {
     }
 
     // Executes the API call to fetch the capabilities of file with provided itemID
-    public static async getCapabilities(siteUrl: string, itemId: string, loginConfig: IOdspTestLoginInfo)
+    public async getCapabilities(siteUrl: string, itemId: string)
     {
-        const tokenConfig: TokenConfig = {
-            ...loginConfig,
-            ...getMicrosoftConfiguration(),
-        };
-        var storageToken = await this.getStorageToken({ siteUrl, refresh: true }, tokenConfig);
+        var storageToken = await this.getStorageToken({ siteUrl, refresh: true });
         const authRequestInfo = {
             accessToken: storageToken,
-            refreshTokenFn: async () => this.getStorageToken({ siteUrl, refresh: true }, tokenConfig),
+            refreshTokenFn: async () => this.getStorageToken({ siteUrl, refresh: true }),
         };
         const url = siteUrl + "/_api/v2.1/drive/items/"+ itemId + "/opStream/capabilities?$select=*";
         await getAsync(url, authRequestInfo)

--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -22,6 +22,7 @@ import { TelemetryLogger } from "@fluidframework/telemetry-utils";
 import { ISequencedDocumentMessage } from "@fluidframework/protocol-definitions";
 import { ILoadTestConfig } from "./testConfigFile";
 import { LeaderElection } from "./leaderElection";
+import { OdspTestDriver } from "@fluidframework/test-drivers";
 export interface IRunConfig {
     runId: number;
     testConfig: ILoadTestConfig;
@@ -461,11 +462,65 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
 
         const opsRun = this.sendOps(dataModel, config, timeout)
         const signalsRun = this.sendSignals(config, timeout)
+        this.startExtractLabel(dataModel, config, (this.context.containerRuntime as any).context.container._resolvedUrl.siteUrl, (this.context.containerRuntime as any).context.container._resolvedUrl.itemId);
+        this.startGetCapabilities(dataModel, config, (this.context.containerRuntime as any).context.container._resolvedUrl.siteUrl, (this.context.containerRuntime as any).context.container._resolvedUrl.itemId);
         const runResult = await Promise.all([opsRun, signalsRun]); //runResult is of type [boolean, void] as we return boolean for Ops alone based on runtime.disposed value
         return runResult[0];
     }
     async getRuntime() {
         return this.runtime;
+    }
+    async startExtractLabel(dataModel, config, siteUrl, itemId)
+    {
+        const creds = {};
+        const envVar = { ...process.env };
+        var credsObj;
+        if(envVar.login__odsp__test__accounts !== undefined){
+            credsObj = JSON.parse(envVar.login__odsp__test__accounts);
+        } 
+        const username = Object.keys(credsObj)[0];
+        creds[username] = credsObj[username];
+        const loginConfig = {
+            username:username,
+            password: creds[username],
+            siteUrl,
+            supportsBrowserAuth: false,
+        }
+        
+        const clientSendCount = config.testConfig.totalSendCount / config.testConfig.numClients;
+        while (dataModel.counter.value < clientSendCount && !this.disposed){
+            await OdspTestDriver.extractSensitivityLabel(siteUrl, itemId, loginConfig);
+            // scheduleCallDelay is the duration between 2 calls for extracting labels in minutes.
+            const scheduleCallDelay = 15;  // in minutes
+            await delay(scheduleCallDelay*60*1000);
+        }
+        
+    }
+    async startGetCapabilities(dataModel, config, siteUrl, itemId)
+    {
+        const creds = {};
+        const envVar = { ...process.env };
+        var credsObj;
+        if(envVar.login__odsp__test__accounts !== undefined){
+            credsObj = JSON.parse(envVar.login__odsp__test__accounts);
+        } 
+        const username = Object.keys(credsObj)[0];
+        creds[username] = credsObj[username];
+        const loginConfig = {
+            username:username,
+            password: creds[username],
+            siteUrl,
+            supportsBrowserAuth: false,
+        }
+        
+        const clientSendCount = config.testConfig.totalSendCount / config.testConfig.numClients;
+        while (dataModel.counter.value < clientSendCount && !this.disposed){
+            await OdspTestDriver.getCapabilities(siteUrl, itemId, loginConfig);
+            // scheduleCallDelay is the duration between 2 calls for extracting labels in minutes.
+            const scheduleCallDelay = 15;  // in minutes
+            await delay(scheduleCallDelay*60*1000);
+        }
+        
     }
     async sendOps(dataModel: LoadTestDataStoreModel, config: IRunConfig, timeout: NodeJS.Timeout | undefined){
         const cycleMs = config.testConfig.readWriteCycleMs;

--- a/packages/test/test-service-load/src/loadTestDataStore.ts
+++ b/packages/test/test-service-load/src/loadTestDataStore.ts
@@ -462,8 +462,11 @@ class LoadTestDataStore extends DataObject implements ILoadTest {
 
         const opsRun = this.sendOps(dataModel, config, timeout)
         const signalsRun = this.sendSignals(config, timeout)
-        this.startExtractLabel(dataModel, config, (this.context.containerRuntime as any).context.container._resolvedUrl.siteUrl, (this.context.containerRuntime as any).context.container._resolvedUrl.itemId);
-        this.startGetCapabilities(dataModel, config, (this.context.containerRuntime as any).context.container._resolvedUrl.siteUrl, (this.context.containerRuntime as any).context.container._resolvedUrl.itemId);
+        if(process.env.LoadTestDriver === "odsp")
+        {
+            this.startExtractLabel(dataModel, config, (this.context.containerRuntime as any).context.container._resolvedUrl.siteUrl, (this.context.containerRuntime as any).context.container._resolvedUrl.itemId);
+            this.startGetCapabilities(dataModel, config, (this.context.containerRuntime as any).context.container._resolvedUrl.siteUrl, (this.context.containerRuntime as any).context.container._resolvedUrl.itemId);
+        }
         const runResult = await Promise.all([opsRun, signalsRun]); //runResult is of type [boolean, void] as we return boolean for Ops alone based on runtime.disposed value
         return runResult[0];
     }

--- a/packages/test/test-service-load/src/nodeStressTest.ts
+++ b/packages/test/test-service-load/src/nodeStressTest.ts
@@ -54,6 +54,7 @@ async function main() {
         .option("-m, --enableMetrics", "Enable capturing client & ops metrics")
         .option("--createTestId", "Flag indicating whether to create a document corresponding \
         to the testId passed")
+        .option("-lb, --label <filepath>", "Filename containing label ids for tenants")
         .parse(process.argv);
 
     const driver: TestDriverTypes = commander.driver;
@@ -68,7 +69,7 @@ async function main() {
     const credFile: string | undefined = commander.credFile;
     const enableMetrics: boolean = commander.enableMetrics ?? false;
     const createTestId: boolean = commander.createTestId ?? false;
-
+    const label: string | undefined  = commander.label;
     const profile = getProfile(profileArg);
 
     if (log !== undefined) {
@@ -77,11 +78,24 @@ async function main() {
 
     const testUsers = await getTestUsers(credFile);
 
+    let labelData = "";
+    if (label !== undefined)
+    {
+        try {
+            var labelDataObj = JSON.parse(fs.readFileSync(label, "utf8"));
+            labelData = JSON.stringify(labelDataObj);
+        }
+        catch (e) {
+            console.error(`Failed to read ${label}`);
+            console.error(e);
+        }
+    }
+
     await orchestratorProcess(
         driver,
         endpoint,
         { ...profile, name: profileArg, testUsers },
-        { testId, debug, verbose, seed, browserAuth, enableMetrics, createTestId });
+        { testId, debug, verbose, seed, browserAuth, enableMetrics, createTestId }, labelData);
 }
 
 /**
@@ -92,7 +106,7 @@ async function orchestratorProcess(
     endpoint: DriverEndpoint | undefined,
     profile: ILoadTestConfig & { name: string; testUsers?: ITestUserConfig; },
     args: { testId?: string; debug?: true; verbose?: true; seed?: number; browserAuth?: true;
-        enableMetrics?: boolean; createTestId?: boolean; },
+        enableMetrics?: boolean; createTestId?: boolean; }, labelData: string,
 ) {
     const seed = args.seed ?? Date.now();
     const seedArg = `0x${seed.toString(16)}`;
@@ -129,6 +143,7 @@ async function orchestratorProcess(
             "--runId", i.toString(),
             "--url", url,
             "--seed", seedArg,
+            "--labelData", labelData,
         ];
         if (args.debug === true) {
             const debugPort = 9230 + i; // 9229 is the default and will be used for the root orchestrator process

--- a/packages/test/test-service-load/src/nodeStressTest.ts
+++ b/packages/test/test-service-load/src/nodeStressTest.ts
@@ -79,7 +79,7 @@ async function main() {
     const testUsers = await getTestUsers(credFile);
 
     let labelData = "";
-    if (label !== undefined)
+    if (label !== undefined && driver === "odsp")
     {
         try {
             var labelDataObj = JSON.parse(fs.readFileSync(label, "utf8"));
@@ -118,7 +118,8 @@ async function orchestratorProcess(
         seed,
         undefined,
         args.browserAuth);
-
+    
+    process.env['LoadTestDriver'] = driver;
     let url;
     if (args.testId !== undefined && args.createTestId === false) {
         // If testId is provided and createTestId is false, then load the file;

--- a/packages/test/test-service-load/src/runner.ts
+++ b/packages/test/test-service-load/src/runner.ts
@@ -233,7 +233,7 @@ async function runnerProcess(
             }
             
             // Block is executed when data is provided to set the sensitivity labels on file.
-            if(labelData.length > 0)
+            if(labelData.length > 0 && driver === "odsp")
             {
                 var labelDataObj = JSON.parse(labelData);
                 var siteUrl;

--- a/packages/utils/odsp-doclib-utils/src/odspRequest.ts
+++ b/packages/utils/odsp-doclib-utils/src/odspRequest.ts
@@ -44,6 +44,13 @@ export async function postAsync(
     });
 }
 
+export async function postAsyncHeader(url: string, requestOption: any): Promise<Response> {
+    //Auth token is passed in the header in requestOption
+    return safeRequestCore(async () => {
+        return fetch(url, requestOption);
+    });
+}
+
 export async function unauthPostAsync(url: string, body: any): Promise<Response> {
     return safeRequestCore(async () => {
         return fetch(url, { body, method: "POST" });


### PR DESCRIPTION
The changes made in the following PR add CLP scenarios to the existing scale test codebase. The CLP scenarios targeted here are setLabel, extractSensitivityLabel and getCapabilities. 

## Description

### nodeStresstest.ts
> The changes require a json file consisting of tenant url & label ID as a key-value pair to be passed for tenants if labels are to be activated.
> This file reads the file path and passes the label ID data to further functions.

### runner.ts
> This file gets the label data read earlier and uses it to apply label to file after it is created.
> For this an API call is made with site url, item ID, label ID and login credentials as the parameters.

### odspTestDriver.ts
> The file contains the block to be executed for all the API calls needed for CLP scenarios.
> The reason for selecting this specific file is that it contains the functions to get authorisation tokens needed to make the API calls.

### loadTestDataStore.ts
> The file calls the extractSensitivityLabel and getCapabilities functions for the file.
> The functions are called in asynchronous manner at an interval of every 15 minutes till the file continues to receive operations. 



